### PR TITLE
V3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,17 @@ jobs:
           ./build -c gcc
           echo "$PWD/out" >> "$GITHUB_PATH"
 
-      # -d turns on ASan for the examples; the suite has its own TSan case
+      # -d turns on ASan for the examples; the suite has its own TSan cases
       - name: Examples under AddressSanitizer
         run: |
           cc build.c -o build
           ./build -d -c gcc -x g++
+          for exe in out/*; do [ -x "$exe" ] && [ -f "$exe" ] && "$exe" >/dev/null; done
+
+      # 09_threads and 10_app are the ones with anything to race.
+      - name: Examples under ThreadSanitizer
+        run: |
+          ./build -d -T -c gcc -x g++
           for exe in out/*; do [ -x "$exe" ] && [ -f "$exe" ] && "$exe" >/dev/null; done
 
       - name: Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Introduced `Logcie_WriterFlushFn` and `flush` field of `Logcie_Writer`.
   Flush is responsible for sending rest of the buffered data to its destination.
   It can be either calling fflush or write into a socket.
+- Introduced `logcie_flush()`. It will iterate over every registred sinks and
+  will call their flushers
 
 ## v2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Upcoming
 
+### Added
+- Introduced `Logcie_WriterFlushFn` and `flush` field of `Logcie_Writer`.
+  Flush is responsible for sending rest of the buffered data to its destination.
+  It can be either calling fflush or write into a socket.
+
 ## v2.0.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   It can be either calling fflush or write into a socket.
 - Introduced `logcie_flush()`. It will iterate over every registred sinks and
   will call their flushers
+- Introduced `LOGCIE_AUTOFLUSH_LEVEL`. If log with this or higher level is encountered
+  it will force call writer flush.
+- Introduced `LOGCIE_AUTOFLUSH_DISABLE`. It will disable automatic sink flusing.
 
 ## v2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,23 @@
 ## Upcoming
 
 ### Added
-- Introduced `Logcie_WriterFlushFn` and `flush` field of `Logcie_Writer`.
-  Flush is responsible for sending rest of the buffered data to its destination.
-  It can be either calling fflush or write into a socket.
-- Introduced `logcie_flush()`. It will iterate over every registred sinks and
-  will call their flushers
-- Introduced `LOGCIE_AUTOFLUSH_LEVEL`. If log with this or higher level is encountered
-  it will force call writer flush.
-- Introduced `LOGCIE_AUTOFLUSH_DISABLE`. It will disable automatic sink flusing.
+- `Logcie_Writer` gained a `flush` field, for destinations that buffer. It is
+  called with the same `data` as `write`, and `NULL` means there is nothing to
+  flush. `logcie_file_flush` is the built-in one to pair with
+  `logcie_file_writer`.
+- `logcie_flush()` flushes every registered sink. Call it before exiting, and
+  before removing a sink -- logcie does not flush on removal, because closing
+  the destination is yours to do.
+- Logs at `LOGCIE_AUTOFLUSH_LEVEL` or above now flush the sink they were
+  written to, so a crash does not take the lines explaining it. Defaults to
+  `LOGCIE_LEVEL_ERROR`; define `LOGCIE_AUTOFLUSH_DISABLE` to switch it off.
+
+### Changed
+- **You are affected if you initialize `Logcie_Writer` positionally.** The
+  struct is now `{write, flush, data}`, so `{my_writer, target}` puts your
+  target in the flush slot. Add the flush argument, or `NULL`:
+  `{my_writer, NULL, target}`. Designated initializers (`.write`, `.data`) do
+  not need changing.
 
 ## v2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,18 @@
   `logcie_file_writer`.
 - `logcie_flush()` flushes every registered sink. Call it before exiting, and
   before removing a sink -- logcie does not flush on removal, because closing
-  the destination is yours to do.
+  the destination is yours to do. It is safe to call from inside a formatter or
+  a writer, unlike logging, which is refused there unless
+  `LOGCIE_ALLOW_RECURSIVE_LOGGING` is defined.
 - Logs at `LOGCIE_AUTOFLUSH_LEVEL` or above now flush the sink they were
   written to, so a crash does not take the lines explaining it. Defaults to
   `LOGCIE_LEVEL_ERROR`; define `LOGCIE_AUTOFLUSH_DISABLE` to switch it off.
+
+### Fixed
+- `logcie.h` builds with `NDEBUG` again. A probe in `logcie_set_colors` was
+  used only inside an assertion, so once assertions compiled away
+  `-Wall -Wextra -Werror` rejected it.
+
 
 ### Changed
 - **You are affected if you initialize `Logcie_Writer` positionally.** The

--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ that supports multiple output sinks, customizable formatting, and flexible filte
 - Support for multiple sinks (stdout, file, etc.)
 - c11/c99 compatible (with -pedantic file)
 
-
 ## Table of Contents
 
 - [Quick Start](#quick-start)
 - [Installation](#installation)
-- [Migrating From v1](#migrating-from-v1)
+- [Migrating From v2](#migrating-from-v2)
 - [Building Examples](#building-examples)
 - [Basic Usage](#basic-usage)
 - [Log Levels](#log-levels)
@@ -71,26 +70,30 @@ int main() {
 #include "logcie.h"
 ```
 
-## Migrating From v1
+## Migrating From v2
 
-Writers gain a parameter and lose the varargs:
+`Logcie_Writer` gained a `flush` field, in the middle:
 
 ```c
-/* v1 */ size_t w(void *data, const char *fmt, va_list *va, ...);
-/* v2 */ size_t w(void *data, const Logcie_Log *log, const char *bytes, size_t len);
+/* v2 */ typedef struct { Logcie_WriterFn *write; void *data; } Logcie_Writer;
+/* v3 */ typedef struct { Logcie_WriterFn *write; Logcie_WriterFlushFn *flush; void *data; } Logcie_Writer;
 ```
 
-Write `bytes` directly; there is no format string to interpret. `log->msg` is
-the format string from the call site, *not* the rendered text.
+If you initialize it positionally, your target now lands in the flush slot.
+Add the flush argument, or `NULL`:
 
-Rename `logcie_printf_formatter` to `logcie_token_formatter` and
-`logcie_printf_writer` to `logcie_file_writer`.
+```c
+/* v2 */ .writer = {my_writer, target}
+/* v3 */ .writer = {my_writer, NULL, target}
+```
 
-If you relied on the first `logcie_add_sink` removing the built-in sink, call
-`logcie_remove_sink(logcie_get_default_sink())` explicitly.
+Designated initializers (`.write`, `.data`) need no change. `logcie_file_flush`
+is the built-in flush to pair with `logcie_file_writer`.
 
-`$<n` pads to `n` columns rather than `n-1`, so a format tuned against the old
-behaviour gains one space.
+Nothing else moved, and nothing has to be flushed for logging to keep working.
+But two behaviours are new and worth knowing about: a log at
+`LOGCIE_AUTOFLUSH_LEVEL` or above (`LOGCIE_LEVEL_ERROR` by default) now flushes
+the sink it was written to, and `logcie_flush()` exists for the rest. See [Flush](#flush).
 
 ## Configuration Macros
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ that supports multiple output sinks, customizable formatting, and flexible filte
 - [Architecture Overview](#architecture-overview)
   - [Formatter](#formatter)
   - [Writer](#writer)
+  - [Flush](#flush)
   - [Filter](#filter)
 - [Configuration Macros](#configuration-macros)
 - [Recursive Logging](#recursive-logging)
@@ -107,6 +108,8 @@ Define any of these **before** you include `logcie.h` (or before
 | `LOGCIE_COLOR_*`                 | ANSI escape codes for each level color. You can override them or use `logcie_set_colors()`.                        | *(see source)*           |
 | `LOGCIE_MODULE_SEPARATOR`        | Character separating levels of a module name. (see [Module-Based Logging](#module-based-logging))                  | `'.'`                    |
 | `LOGCIE_MAX_SINKS`               | How many sinks can be registered at once. `logcie_add_sink` returns 0 once full.                                   | `16`                     |
+| `LOGCIE_AUTOFLUSH_LEVEL`         | Level at and above which a log flushes the sink it was written to. (see [Flush](#flush))                           | `LOGCIE_LEVEL_ERROR`     |
+| `LOGCIE_AUTOFLUSH_DISABLE`       | Define it to switch autoflush off entirely. `logcie_flush()` still works.                                          | *(not defined)*          |
 | `LOGCIE_MAX_LINE`                | Stack buffer a line is formatted into. Lines that fit cost no allocation.                                          | `1024`                   |
 | `LOGCIE_MALLOC` / `LOGCIE_FREE`  | Allocator used *only* for lines longer than `LOGCIE_MAX_LINE`. Define both or neither.                             | `malloc` / `free`        |
 | `LOGCIE_NO_MALLOC`               | Never allocate. Lines longer than `LOGCIE_MAX_LINE` are truncated instead.                                         | *(not defined)*          |
@@ -225,6 +228,39 @@ exactly that, which is the cheapest way to mute a sink without removing it —
 and the first thing to check when a sink is unexpectedly silent, since Logcie
 does not substitute `stdout` for you.
 
+### Flush
+
+Pushes whatever the writer has buffered out to its destination.
+
+```c
+void my_flush(void *user_data);
+```
+
+It lives on the writer rather than beside it, and it is handed the same
+`user_data` as `write`. A flush is only meaningful against the destination that
+was written to, so giving it its own pointer would only make it possible to
+aim the two at different things.
+
+```c
+Logcie_Writer w = {my_writer, my_flush, target};
+```
+
+`NULL` means there is nothing to flush, and such a sink is skipped rather than
+treated as a failure. `logcie_file_flush` is the built-in one, and a `NULL`
+target does nothing — `fflush(NULL)` would flush every open stream in the
+process, which is not one sink's business.
+
+Two things reach it:
+
+- **`logcie_flush()`** walks every registered sink and flushes it. Call it
+  before exiting, and before removing a sink. Logcie does not flush on removal:
+  the sink is yours, and so is closing whatever it writes to.
+- **Autoflush.** A log at `LOGCIE_AUTOFLUSH_LEVEL` or above flushes the sink it
+  was just written to. It defaults to `LOGCIE_LEVEL_ERROR`, because those are
+  the lines a crash would otherwise take with it. Lower it to
+  `LOGCIE_LEVEL_TRACE` to flush everything, or define `LOGCIE_AUTOFLUSH_DISABLE`
+  to switch it off and flush by hand.
+
 ### Filter
 
 Decides whether a log should be emitted.
@@ -264,7 +300,7 @@ This is how default sinks looks like:
 ```c
 static Logcie_Sink default_stdout_sink = {
     .formatter = {logcie_token_formatter, "$c$L$r " LOGCIE_COLOR_GRAY "$f:$x$r: $m"},
-    .writer    = {logcie_file_writer, stdout},
+    .writer    = {logcie_file_writer, logcie_file_flush, stdout},
     .filter    = {NULL, NULL},
 };
 ```
@@ -301,13 +337,18 @@ logcie_remove_all_sinks();
 static Logcie_Sink error_sink = {
     // nice format: date, time, level, module, message
     .formatter = {logcie_token_formatter, "$d $t [$L] $f:$x - $m"},
-    .writer    = {logcie_file_writer, NULL},
+    .writer    = {logcie_file_writer, logcie_file_flush, NULL},
     .filter    = logcie_filter_level_min(LOGCIE_LEVEL_ERROR)
 };
 
 int main(void) {
     error_sink.writer.data = fopen("errors.log", "a");
     logcie_add_sink(&error_sink);
+
+    // ... log ...
+
+    logcie_flush();
+    fclose(error_sink.writer.data);
 }
 ```
 

--- a/build.c
+++ b/build.c
@@ -88,13 +88,13 @@ uint8_t stdout_sink_filter(const void *data, Logcie_Log *log) {
 
 static Logcie_Sink stdout_sink = {
   .formatter = {logcie_token_formatter, LOGCIE_COLOR_GRAY "[$M]$r $c$L$r:$m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {stdout_sink_filter, NULL}
 };
 
 static Logcie_Sink optly_sink = {
   .formatter = {logcie_token_formatter, LOGCIE_COLOR_GRAY "[$M]$r $c$L$r:$m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = logcie_filter_and(
     logcie_filter_module_eq("optly"),
     logcie_filter_level_min(LOGCIE_LEVEL_INFO)

--- a/build.c
+++ b/build.c
@@ -58,7 +58,8 @@ static OptlyCommand command = {
     optly_flag_string("outdir", 'o', "Set output dir", .value.as_string = "." PATH_SEP "out" PATH_SEP),
     optly_flag_string("c-compiler", 'c', "Set which C compier to use", .value.as_string = "clang"),
     optly_flag_string("cpp-compiler", 'x', "Set which C++ compier to use", .value.as_string = "clang++"),
-    optly_flag_bool("dry-run", 'r', "Do not compile but show compile commands")
+    optly_flag_bool("dry-run", 'r', "Do not compile but show compile commands"),
+    optly_flag_bool("thread-sanitizer", 'T', "Compile with thread sanitizer instead of address sanitizer")
   ),
   .commands = optly_commands(
     optly_command(
@@ -560,7 +561,7 @@ static bool build_example(const char *dir, const char *name) {
   if (optly_flag_value_bool(&command, "debug")) {
     cmd[i++] = "-ggdb";
 #ifndef _WIN32
-    cmd[i++] = "-fsanitize=address";
+    cmd[i++] = optly_flag_value_bool(&command, "thread-sanitizer") ? "-fsanitize=thread" : "-fsanitize=address";
 #endif
     cmd[i++] = "-fno-omit-frame-pointer";
     cmd[i++] = "-DLOGCIE_DEBUG_CHECKS";

--- a/examples/03_sinks/main.c
+++ b/examples/03_sinks/main.c
@@ -23,7 +23,7 @@ int main(void) {
 
   Logcie_Sink file_sink = {
     .formatter = {logcie_token_formatter, "$d $t [$L] ($M) $m"},
-    .writer    = {logcie_file_writer, logfile},
+    .writer    = {logcie_file_writer, logcie_file_flush, logfile},
     .filter    = {NULL, NULL}
   };
 

--- a/examples/04_filters/main.c
+++ b/examples/04_filters/main.c
@@ -18,7 +18,7 @@ void net_work(void);
 // Everything at INFO and above, plus anything from net.* at any level.
 static Logcie_Sink console = {
   .formatter = {logcie_token_formatter, "[$L] ($M) $m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = logcie_filter_or(
     logcie_filter_level_min(LOGCIE_LEVEL_INFO),
     logcie_filter_module_prefix_eq("net")

--- a/examples/05_custom_writer/main.c
+++ b/examples/05_custom_writer/main.c
@@ -26,7 +26,7 @@ static size_t console_writer(void *user_data, const Logcie_Log *log, const char 
 
 static Logcie_Sink console = {
   .formatter = {logcie_token_formatter, "[$L] $m"},
-  .writer    = {console_writer, NULL},
+  .writer    = {console_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL}
 };
 

--- a/examples/06_custom_formatter/main.c
+++ b/examples/06_custom_formatter/main.c
@@ -63,7 +63,7 @@ static size_t json_formatter(Logcie_Writer *writer, void *user_data, Logcie_Log 
 
 static Logcie_Sink json_sink = {
   .formatter = {json_formatter, NULL},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL}
 };
 

--- a/examples/10_app/main.c
+++ b/examples/10_app/main.c
@@ -26,11 +26,17 @@ static size_t console_writer(void *user_data, const Logcie_Log *log, const char 
   return fwrite(bytes, 1, len, out);
 }
 
+static void console_flush(void *user_data) {
+  (void)user_data;
+  fflush(stdout);
+  fflush(stderr);
+}
+
 // Console: INFO and up, but never the storage chatter. Neither storage.c nor
 // api.c is aware of this.
 static Logcie_Sink console = {
   .formatter = {logcie_token_formatter, "$c$L$<6$r ($M) $m"},
-  .writer    = {console_writer, logcie_file_flush, NULL},
+  .writer    = {console_writer, console_flush, NULL},
   .filter    = logcie_filter_and(
     logcie_filter_level_min(LOGCIE_LEVEL_INFO),
     logcie_filter_not(logcie_filter_module_prefix_eq("app.storage"))
@@ -63,6 +69,8 @@ int main(void) {
   storage_close();
 
   LOGCIE_INFO("done, see app.log for the full trace");
+
+  logcie_flush();
 
   fclose((FILE *)logfile.writer.data);
   return 0;

--- a/examples/10_app/main.c
+++ b/examples/10_app/main.c
@@ -30,7 +30,7 @@ static size_t console_writer(void *user_data, const Logcie_Log *log, const char 
 // api.c is aware of this.
 static Logcie_Sink console = {
   .formatter = {logcie_token_formatter, "$c$L$<6$r ($M) $m"},
-  .writer    = {console_writer, NULL},
+  .writer    = {console_writer, logcie_file_flush, NULL},
   .filter    = logcie_filter_and(
     logcie_filter_level_min(LOGCIE_LEVEL_INFO),
     logcie_filter_not(logcie_filter_module_prefix_eq("app.storage"))
@@ -40,7 +40,7 @@ static Logcie_Sink console = {
 // File: everything, with enough detail to debug from afterwards.
 static Logcie_Sink logfile = {
   .formatter = {logcie_token_formatter, "$d $t.$N [$l] $M $f:$x $m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL}
 };
 

--- a/examples/12_cpp/main.cpp
+++ b/examples/12_cpp/main.cpp
@@ -25,7 +25,7 @@ int main() {
   // built as C++11
   Logcie_Sink console = {
     {logcie_token_formatter, (void *)"[$L] ($M) $m"},
-    {console_writer, NULL},
+    {console_writer, logcie_file_flush, NULL},
     logcie_filter_and(
       logcie_filter_level_min(LOGCIE_LEVEL_INFO),
       logcie_filter_not(logcie_filter_module_eq("noisy"))

--- a/logcie.h
+++ b/logcie.h
@@ -1182,9 +1182,7 @@ LOGCIE_MUTEX_DECLARE(logcie_mutex);
 #warning "No thread local storage support"
 #endif
 
-#ifndef LOGCIE_ALLOW_RECURSIVE_LOGGING
 static LOGCIE_THREAD_LOCAL int logcie_log_depth = 0;
-#endif
 
 // NOTE: localtime and gmtime hand back a pointer into storage shared across the
 // process, so two threads formatting at once can read a struct the other is
@@ -1418,9 +1416,7 @@ void logcie_remove_all_sinks(void) {
   LOGCIE_MUTEX_UNLOCK(logcie_mutex);
 }
 
-LOGCIE_DEF void logcie_flush(void) {
-  LOGCIE_MUTEX_LOCK(logcie_mutex);
-
+static void logcie_flush_locked(void) {
   for (size_t i = 0; i < logcie.sinks_len; i++) {
     Logcie_WriterFlushFn *flusher = logcie.sinks[i]->writer.flush;
 
@@ -1428,7 +1424,17 @@ LOGCIE_DEF void logcie_flush(void) {
       flusher(logcie.sinks[i]->writer.data);
     }
   }
+}
 
+LOGCIE_DEF void logcie_flush(void) {
+  if (logcie_log_depth > 0) {
+    // Already locked
+    logcie_flush_locked();
+    return;
+  }
+
+  LOGCIE_MUTEX_LOCK(logcie_mutex);
+  logcie_flush_locked();
   LOGCIE_MUTEX_UNLOCK(logcie_mutex);
 }
 
@@ -1437,9 +1443,9 @@ size_t logcie_log(Logcie_Log log, const char *fmt, ...) {
   if (logcie_log_depth > 0) {
     return 0;
   }
+#endif
 
   logcie_log_depth++;
-#endif
 
   LOGCIE_MUTEX_LOCK(logcie_mutex);
 
@@ -1469,10 +1475,7 @@ size_t logcie_log(Logcie_Log log, const char *fmt, ...) {
   }
 
   LOGCIE_MUTEX_UNLOCK(logcie_mutex);
-
-#ifndef LOGCIE_ALLOW_RECURSIVE_LOGGING
   logcie_log_depth--;
-#endif
 
   va_end(args);
   return 0;

--- a/logcie.h
+++ b/logcie.h
@@ -856,6 +856,15 @@ LOGCIE_DEF uint8_t logcie_remove_sink_by_index(size_t index);
 LOGCIE_DEF void logcie_remove_all_sinks(void);
 
 /**
+ * @brief Flushes all registerd sinks.
+ *
+ * Iterates for every registered sink and calls its flusher, if it exists.
+ *
+ * @returns total size of all flushed bytes
+ */
+LOGCIE_DEF size_t logcie_flush(void);
+
+/**
  * @brief Default formatter using printf-style formatting and $ tokens.
  *
  * This is the built-in formatter that provides rich formatting capabilities
@@ -1384,6 +1393,18 @@ void logcie_remove_all_sinks(void) {
   LOGCIE_MUTEX_LOCK(logcie_mutex);
   logcie.sinks_len = 0;
   LOGCIE_MUTEX_UNLOCK(logcie_mutex);
+}
+
+LOGCIE_DEF size_t logcie_flush(void) {
+  size_t res = 0;
+  LOGCIE_MUTEX_LOCK(logcie_mutex);
+
+  for (size_t i = 0; i < logcie.sinks_len; i++) {
+    res += logcie.sinks[i]->writer.flush(logcie.sinks[i]->writer.data);
+  }
+
+  LOGCIE_MUTEX_UNLOCK(logcie_mutex);
+  return res;
 }
 
 size_t logcie_log(Logcie_Log log, const char *fmt, ...) {

--- a/logcie.h
+++ b/logcie.h
@@ -1400,7 +1400,11 @@ LOGCIE_DEF size_t logcie_flush(void) {
   LOGCIE_MUTEX_LOCK(logcie_mutex);
 
   for (size_t i = 0; i < logcie.sinks_len; i++) {
-    res += logcie.sinks[i]->writer.flush(logcie.sinks[i]->writer.data);
+    Logcie_WriterFlushFn *flusher = logcie.sinks[i]->writer.flush;
+
+    if (flusher) {
+      res += flusher(logcie.sinks[i]->writer.data);
+    }
   }
 
   LOGCIE_MUTEX_UNLOCK(logcie_mutex);

--- a/logcie.h
+++ b/logcie.h
@@ -58,6 +58,7 @@
  *          is safe. It also gets the log itself, for metadata a transport needs as a
  *          separate value rather than as text. A NULL user_data discards, which is
  *          /dev/null without the open().
+ *          Also writer has a flush. A flush is basically an fflush.
  *   Filter decides whether a log reaches the Sink at all. See the Filters section below for the built-i
  *          ones and how to combine them.
  *
@@ -94,7 +95,7 @@
  *   It would not be that great if Logcie was just empty framework and you need to set it up by yourself,
  *   so Logcie comes with a couple of pre-defined functions:
  *
- *      - logcie_file_writer      - built-in writer. Writes the formatted line to a FILE *
+ *      - logcie_file_writer      - built-in writer. Writes the formatted line to a FILE * and have a fflush as flush
  *      - logcie_token_formatter - built-in formatter that provides rich formatting using $ tokens. Here is the list:
  *                                   `$m` - Log message with printf formatting
  *                                   `$f` - Source file name
@@ -291,13 +292,13 @@
  *     //       there and fill the writer target in at run time.
  *     Logcie_Sink stdout_sink = {
  *       .formatter = { logcie_token_formatter, "[$L] $m" },
- *       .writer = { logcie_file_writer, NULL },
+ *       .writer = { logcie_file_writer, logcie_file_flush, NULL },
  *       .filter = { logcie_filter_level_min_fn, LOGCIE_LEVEL_INFO }
  *     };
  *
  *     Logcie_Sink file_sink = {
  *       .formatter = { logcie_token_formatter, "$L:$f:$x: $m ($t $d)" },
- *       .writer = { logcie_file_writer, NULL },
+ *       .writer = { logcie_file_writer, logcie_file_flush, NULL },
  *     };
  *
  *     int main(void) {
@@ -527,16 +528,29 @@ typedef struct Logcie_Log Logcie_Log;
 typedef size_t(Logcie_WriterFn)(void *user_data, const Logcie_Log *log, const char *bytes, size_t len);
 
 /**
+ * @brief Writer flush function type signature
+ *
+ * Flush is responsible for sending rest of the buffered data to its destination.
+ * It can be either calling fflush or write into a socket.
+ *
+ * @param user_data  Destination for this writer (FILE *, socket, ...)
+ * @return Number of bytes flushed
+ */
+typedef size_t(Logcie_WriterFlushFn)(void *user_data);
+
+/**
  * @brief Writer struct
  *
  * Stores writer function pointer and custom data for it
  *
  * @param write  Writer function pointer
+ * @param flush  Flush function pointer
  * @param data   Custom data for writer function
  */
 typedef struct Logcie_Writer {
-  Logcie_WriterFn *write;
-  void            *data;
+  Logcie_WriterFn      *write;
+  Logcie_WriterFlushFn *flush;
+  void                 *data;
 } Logcie_Writer;
 
 /**
@@ -702,21 +716,21 @@ struct Logcie_Log {
 // into separate macro arguments.
 #define LOGCIE_INTERNAL_EXPAND(x) x
 
-#define LOGCIE_TRACE(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(TRACE, __VA_ARGS__))
-#define LOGCIE_DEBUG(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(DEBUG, __VA_ARGS__))
+#define LOGCIE_TRACE(...)   LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(TRACE, __VA_ARGS__))
+#define LOGCIE_DEBUG(...)   LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(DEBUG, __VA_ARGS__))
 #define LOGCIE_VERBOSE(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(VERBOSE, __VA_ARGS__))
-#define LOGCIE_INFO(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(INFO, __VA_ARGS__))
-#define LOGCIE_WARN(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(WARN, __VA_ARGS__))
-#define LOGCIE_ERROR(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(ERROR, __VA_ARGS__))
-#define LOGCIE_FATAL(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(FATAL, __VA_ARGS__))
+#define LOGCIE_INFO(...)    LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(INFO, __VA_ARGS__))
+#define LOGCIE_WARN(...)    LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(WARN, __VA_ARGS__))
+#define LOGCIE_ERROR(...)   LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(ERROR, __VA_ARGS__))
+#define LOGCIE_FATAL(...)   LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(FATAL, __VA_ARGS__))
 
-#define LOGCIE_TRACE_MOD(mod, ...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, TRACE, __VA_ARGS__))
-#define LOGCIE_DEBUG_MOD(mod, ...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, DEBUG, __VA_ARGS__))
+#define LOGCIE_TRACE_MOD(mod, ...)   LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, TRACE, __VA_ARGS__))
+#define LOGCIE_DEBUG_MOD(mod, ...)   LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, DEBUG, __VA_ARGS__))
 #define LOGCIE_VERBOSE_MOD(mod, ...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, VERBOSE, __VA_ARGS__))
-#define LOGCIE_INFO_MOD(mod, ...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, INFO, __VA_ARGS__))
-#define LOGCIE_WARN_MOD(mod, ...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, WARN, __VA_ARGS__))
-#define LOGCIE_ERROR_MOD(mod, ...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, ERROR, __VA_ARGS__))
-#define LOGCIE_FATAL_MOD(mod, ...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, FATAL, __VA_ARGS__))
+#define LOGCIE_INFO_MOD(mod, ...)    LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, INFO, __VA_ARGS__))
+#define LOGCIE_WARN_MOD(mod, ...)    LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, WARN, __VA_ARGS__))
+#define LOGCIE_ERROR_MOD(mod, ...)   LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, ERROR, __VA_ARGS__))
+#define LOGCIE_FATAL_MOD(mod, ...)   LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_MOD(mod, FATAL, __VA_ARGS__))
 
 #define LOGCIE_LOG(level, ...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL(level, __VA_ARGS__))
 
@@ -725,13 +739,13 @@ struct Logcie_Log {
 #define LOGCIE_LOG_IMPL_VA(level, msg, ...)        logcie_log(LOGCIE_INTERNAL_CREATE_LOG(LOGCIE_LEVEL_##level, msg, __FILE__, __LINE__), msg, __VA_ARGS__)
 #define LOGCIE_LOG_MOD_VA(module, level, msg, ...) logcie_log(LOGCIE_INTERNAL_CREATE_LOG_MOD(module, LOGCIE_LEVEL_##level, msg, __FILE__, __LINE__), msg, __VA_ARGS__)
 
-#define LOGCIE_TRACE_VA(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(TRACE, __VA_ARGS__))
-#define LOGCIE_DEBUG_VA(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(DEBUG, __VA_ARGS__))
-#define LOGCIE_VERBOSE_VA(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(VERBOSE, __VA_ARGS__))
-#define LOGCIE_INFO_VA(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(INFO, __VA_ARGS__))
-#define LOGCIE_WARN_VA(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(WARN, __VA_ARGS__))
-#define LOGCIE_ERROR_VA(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(ERROR, __VA_ARGS__))
-#define LOGCIE_FATAL_VA(...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(FATAL, __VA_ARGS__))
+#define LOGCIE_TRACE_VA(...)      LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(TRACE, __VA_ARGS__))
+#define LOGCIE_DEBUG_VA(...)      LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(DEBUG, __VA_ARGS__))
+#define LOGCIE_VERBOSE_VA(...)    LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(VERBOSE, __VA_ARGS__))
+#define LOGCIE_INFO_VA(...)       LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(INFO, __VA_ARGS__))
+#define LOGCIE_WARN_VA(...)       LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(WARN, __VA_ARGS__))
+#define LOGCIE_ERROR_VA(...)      LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(ERROR, __VA_ARGS__))
+#define LOGCIE_FATAL_VA(...)      LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(FATAL, __VA_ARGS__))
 #define LOGCIE_LOG_VA(level, ...) LOGCIE_INTERNAL_EXPAND(LOGCIE_LOG_IMPL_VA(level, __VA_ARGS__))
 #endif
 
@@ -889,6 +903,15 @@ LOGCIE_DEF size_t logcie_token_formatter(Logcie_Writer *writer, void *user_data,
  *       does not substitute stdout for you.
  */
 LOGCIE_DEF size_t logcie_file_writer(void *user_data, const Logcie_Log *log, const char *bytes, size_t len);
+
+/**
+ * @brief Built-in flusher for build-in file wirter
+ * @see logcie_file_writer
+ *
+ * @param user_data  FILE * to write to, or NULL to discard
+ * @return Number of bytes flushed
+ */
+LOGCIE_DEF size_t logcie_file_flush(void *user_data);
 
 /**
  * @brief Renders the user's message into a buffer.
@@ -1243,7 +1266,7 @@ static inline const char *get_logcie_level_color(Logcie_LogLevel level) {
 // -pedantic on every earlier standard.
 static Logcie_Sink default_stdout_sink = {
   {logcie_token_formatter, (void *)(LOGCIE_DEFAULT_SINK_FORMAT)},
-  {logcie_file_writer, NULL},
+  {logcie_file_writer, logcie_file_flush, NULL},
   {NULL, NULL},
 };
 
@@ -1650,8 +1673,6 @@ size_t logcie_token_formatter(Logcie_Writer *writer, void *data, Logcie_Log log,
   return sizeof(stack_buf) - 1;
 }
 
-// TODO: logcie_writer_flush()???
-
 LOGCIE_DEF size_t logcie_file_writer(void *user_data, const Logcie_Log *log, const char *bytes, size_t len) {
   (void)log;
 
@@ -1663,6 +1684,10 @@ LOGCIE_DEF size_t logcie_file_writer(void *user_data, const Logcie_Log *log, con
   }
 
   return fwrite(bytes, 1, len, file);
+}
+
+LOGCIE_DEF size_t logcie_file_flush(void *user_data) {
+  return fflush((FILE *)user_data);
 }
 
 LOGCIE_DEF uint8_t logcie_filter_not_fn(const void *data, Logcie_Log *log) {

--- a/logcie.h
+++ b/logcie.h
@@ -27,8 +27,8 @@
  *   LOGCIE_MODULE                  Module name for classic macros (default "Logcie")
  *   LOGCIE_MODULE_SEPARATOR        Moudle names separator for hierarchical module filtering (default '.')
  *   LOGCIE_MAX_SINKS               Maximum capacity of logcie sinks array (default: 16)
- *   LOGCIE_AUTOFLUSH_LEVEL         Maximum log level that fill automatically call flush (default: LOGCIE_LEVEL_ERROR)
- *   LOGCIE_AUTOFLUSH_DISABLE       Disables autoflush. Define to enable (default: not defined)
+ *   LOGCIE_AUTOFLUSH_LEVEL         Level at and above which a log flushes its sink (default: LOGCIE_LEVEL_ERROR)
+ *   LOGCIE_AUTOFLUSH_DISABLE       Define it to switch autoflushing off entierly (default: not defined)
  *   LOGCIE_MAX_LINE                Stack buffer a log line is formatted into (default: 1024)
  *   LOGCIE_MALLOC / LOGCIE_FREE    Allocator for lines longer than LOGCIE_MAX_LINE
  *   LOGCIE_NO_MALLOC               Never allocate; truncate long lines instead
@@ -60,7 +60,8 @@
  *          is safe. It also gets the log itself, for metadata a transport needs as a
  *          separate value rather than as text. A NULL user_data discards, which is
  *          /dev/null without the open().
- *          Also writer has a flush. A flush is basically an fflush.
+ *          A Writer also carries a flush, for destinations that buffer. It is given the
+ *          same user_data as write, and NULL means there is nothing to flush.
  *   Filter decides whether a log reaches the Sink at all. See the Filters section below for the built-i
  *          ones and how to combine them.
  *
@@ -97,7 +98,8 @@
  *   It would not be that great if Logcie was just empty framework and you need to set it up by yourself,
  *   so Logcie comes with a couple of pre-defined functions:
  *
- *      - logcie_file_writer      - built-in writer. Writes the formatted line to a FILE * and have a fflush as flush
+ *      - logcie_file_writer     - built-in writer. Writes the formatted line to a FILE *
+ *      - logcie_file_flush      - built-in flush for it. Calls fflush on that FILE *
  *      - logcie_token_formatter - built-in formatter that provides rich formatting using $ tokens. Here is the list:
  *                                   `$m` - Log message with printf formatting
  *                                   `$f` - Source file name
@@ -495,7 +497,15 @@ typedef enum Logcie_LogLevel {
 #endif
 
 /**
- * @brief Maximum log level that fill automatically call flush
+ * @brief Level at and above which a log line flushes the sink it was written to.
+ *
+ * Buffered output is the output you lose when a process dies, and the lines
+ * worth having then are the ones explaining why. Flushing from ERROR up costs
+ * a syscall on the lines you were going to read anyway.
+ *
+ * Lower it to LOGCIE_LEVEL_TRACE to flush every line, or define
+ * LOGCIE_AUTOFLUSH_DISABLE to switch it off. A sink whose writer has no flush
+ * is skipped either way.
  */
 #ifndef LOGCIE_AUTOFLUSH_LEVEL
 #define LOGCIE_AUTOFLUSH_LEVEL LOGCIE_LEVEL_ERROR
@@ -557,8 +567,8 @@ typedef void(Logcie_WriterFlushFn)(void *user_data);
  * Stores writer function pointer and custom data for it
  *
  * @param write  Writer function pointer
- * @param flush  Flush function pointer
- * @param data   Custom data for writer function
+ * @param flush  Flush function pointer, or NULL when there is nothing to flush
+ * @param data   Custom data, handed to both write and flush
  */
 typedef struct Logcie_Writer {
   Logcie_WriterFn      *write;

--- a/logcie.h
+++ b/logcie.h
@@ -547,9 +547,8 @@ typedef size_t(Logcie_WriterFn)(void *user_data, const Logcie_Log *log, const ch
  * It can be either calling fflush or write into a socket.
  *
  * @param user_data  Destination for this writer (FILE *, socket, ...)
- * @return Number of bytes flushed
  */
-typedef size_t(Logcie_WriterFlushFn)(void *user_data);
+typedef void(Logcie_WriterFlushFn)(void *user_data);
 
 /**
  * @brief Writer struct
@@ -875,7 +874,7 @@ LOGCIE_DEF void logcie_remove_all_sinks(void);
  *
  * @returns total size of all flushed bytes
  */
-LOGCIE_DEF size_t logcie_flush(void);
+LOGCIE_DEF void logcie_flush(void);
 
 /**
  * @brief Default formatter using printf-style formatting and $ tokens.
@@ -931,9 +930,8 @@ LOGCIE_DEF size_t logcie_file_writer(void *user_data, const Logcie_Log *log, con
  * @see logcie_file_writer
  *
  * @param user_data  FILE * to write to, or NULL to discard
- * @return Number of bytes flushed
  */
-LOGCIE_DEF size_t logcie_file_flush(void *user_data);
+LOGCIE_DEF void logcie_file_flush(void *user_data);
 
 /**
  * @brief Renders the user's message into a buffer.
@@ -1408,20 +1406,18 @@ void logcie_remove_all_sinks(void) {
   LOGCIE_MUTEX_UNLOCK(logcie_mutex);
 }
 
-LOGCIE_DEF size_t logcie_flush(void) {
-  size_t res = 0;
+LOGCIE_DEF void logcie_flush(void) {
   LOGCIE_MUTEX_LOCK(logcie_mutex);
 
   for (size_t i = 0; i < logcie.sinks_len; i++) {
     Logcie_WriterFlushFn *flusher = logcie.sinks[i]->writer.flush;
 
     if (flusher) {
-      res += flusher(logcie.sinks[i]->writer.data);
+      flusher(logcie.sinks[i]->writer.data);
     }
   }
 
   LOGCIE_MUTEX_UNLOCK(logcie_mutex);
-  return res;
 }
 
 size_t logcie_log(Logcie_Log log, const char *fmt, ...) {
@@ -1728,8 +1724,10 @@ LOGCIE_DEF size_t logcie_file_writer(void *user_data, const Logcie_Log *log, con
   return fwrite(bytes, 1, len, file);
 }
 
-LOGCIE_DEF size_t logcie_file_flush(void *user_data) {
-  return fflush((FILE *)user_data);
+LOGCIE_DEF void logcie_file_flush(void *user_data) {
+  if (user_data) {
+    fflush((FILE *)user_data);
+  }
 }
 
 LOGCIE_DEF uint8_t logcie_filter_not_fn(const void *data, Logcie_Log *log) {

--- a/logcie.h
+++ b/logcie.h
@@ -502,6 +502,7 @@ typedef enum Logcie_LogLevel {
 #endif
 
 #ifdef LOGCIE_AUTOFLUSH_DISABLE
+#undef LOGCIE_AUTOFLUSH_LEVEL
 #define LOGCIE_AUTOFLUSH_LEVEL Count_LOGCIE_LEVEL
 #endif
 

--- a/logcie.h
+++ b/logcie.h
@@ -27,6 +27,8 @@
  *   LOGCIE_MODULE                  Module name for classic macros (default "Logcie")
  *   LOGCIE_MODULE_SEPARATOR        Moudle names separator for hierarchical module filtering (default '.')
  *   LOGCIE_MAX_SINKS               Maximum capacity of logcie sinks array (default: 16)
+ *   LOGCIE_AUTOFLUSH_LEVEL         Maximum log level that fill automatically call flush (default: LOGCIE_LEVEL_ERROR)
+ *   LOGCIE_AUTOFLUSH_DISABLE       Diables autoflush. Define to enable (default: not defined)
  *   LOGCIE_MAX_LINE                Stack buffer a log line is formatted into (default: 1024)
  *   LOGCIE_MALLOC / LOGCIE_FREE    Allocator for lines longer than LOGCIE_MAX_LINE
  *   LOGCIE_NO_MALLOC               Never allocate; truncate long lines instead
@@ -490,6 +492,17 @@ typedef enum Logcie_LogLevel {
  */
 #ifndef LOGCIE_MAX_SINKS
 #define LOGCIE_MAX_SINKS 16
+#endif
+
+/**
+ * @brief Maximum log level that fill automatically call flush
+ */
+#ifndef LOGCIE_AUTOFLUSH_LEVEL
+#define LOGCIE_AUTOFLUSH_LEVEL LOGCIE_LEVEL_ERROR
+#endif
+
+#ifdef LOGCIE_AUTOFLUSH_DISABLE
+#define LOGCIE_AUTOFLUSH_LEVEL Count_LOGCIE_LEVEL
 #endif
 
 /**
@@ -1439,6 +1452,10 @@ size_t logcie_log(Logcie_Log log, const char *fmt, ...) {
     va_copy(args_copy, args);
 
     sink->formatter.format(&sink->writer, sink->formatter.data, log, &args_copy);
+
+    if (log.level >= LOGCIE_AUTOFLUSH_LEVEL) {
+      sink->writer.flush(sink->writer.data);
+    }
 
     va_end(args_copy);
   }

--- a/logcie.h
+++ b/logcie.h
@@ -1449,7 +1449,7 @@ size_t logcie_log(Logcie_Log log, const char *fmt, ...) {
 
     sink->formatter.format(&sink->writer, sink->formatter.data, log, &args_copy);
 
-    if (log.level >= LOGCIE_AUTOFLUSH_LEVEL) {
+    if (log.level >= LOGCIE_AUTOFLUSH_LEVEL && sink->writer.flush) {
       sink->writer.flush(sink->writer.data);
     }
 

--- a/logcie.h
+++ b/logcie.h
@@ -28,7 +28,7 @@
  *   LOGCIE_MODULE_SEPARATOR        Moudle names separator for hierarchical module filtering (default '.')
  *   LOGCIE_MAX_SINKS               Maximum capacity of logcie sinks array (default: 16)
  *   LOGCIE_AUTOFLUSH_LEVEL         Maximum log level that fill automatically call flush (default: LOGCIE_LEVEL_ERROR)
- *   LOGCIE_AUTOFLUSH_DISABLE       Diables autoflush. Define to enable (default: not defined)
+ *   LOGCIE_AUTOFLUSH_DISABLE       Disables autoflush. Define to enable (default: not defined)
  *   LOGCIE_MAX_LINE                Stack buffer a log line is formatted into (default: 1024)
  *   LOGCIE_MALLOC / LOGCIE_FREE    Allocator for lines longer than LOGCIE_MAX_LINE
  *   LOGCIE_NO_MALLOC               Never allocate; truncate long lines instead

--- a/logcie.h
+++ b/logcie.h
@@ -1278,6 +1278,7 @@ void logcie_set_colors(const char **colors) {
     // If it is compiled without -fsanitize=address then color would be NULL (I hope)
     const char *color = colors[Count_LOGCIE_LEVEL - 1];
     LOGCIE_INTERNAL_ASSERT(color != NULL, "Size of array of colors in logcie_set_colors is not equal to Count_LOGCIE_LEVEL");
+    (void)color;
     logcie_level_color = colors;
   } else {
     logcie_level_color = logcie_default_level_color;

--- a/logcie.h
+++ b/logcie.h
@@ -25,10 +25,10 @@
  *
  * Configuration macros (define before including the header):
  *   LOGCIE_MODULE                  Module name for classic macros (default "Logcie")
- *   LOGCIE_MODULE_SEPARATOR        Moudle names separator for hierarchical module filtering (default '.')
+ *   LOGCIE_MODULE_SEPARATOR        Module names separator for hierarchical module filtering (default '.')
  *   LOGCIE_MAX_SINKS               Maximum capacity of logcie sinks array (default: 16)
  *   LOGCIE_AUTOFLUSH_LEVEL         Level at and above which a log flushes its sink (default: LOGCIE_LEVEL_ERROR)
- *   LOGCIE_AUTOFLUSH_DISABLE       Define it to switch autoflushing off entierly (default: not defined)
+ *   LOGCIE_AUTOFLUSH_DISABLE       Define it to switch autoflushing off entirely (default: not defined)
  *   LOGCIE_MAX_LINE                Stack buffer a log line is formatted into (default: 1024)
  *   LOGCIE_MALLOC / LOGCIE_FREE    Allocator for lines longer than LOGCIE_MAX_LINE
  *   LOGCIE_NO_MALLOC               Never allocate; truncate long lines instead

--- a/tests/api/api.c
+++ b/tests/api/api.c
@@ -3,7 +3,7 @@
 
 static Logcie_Sink sink = {
   .formatter = {logcie_token_formatter, (void *)"$c$L$r $m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/cplusplus/cpp.cpp
+++ b/tests/cplusplus/cpp.cpp
@@ -6,7 +6,7 @@
 
 static Logcie_Sink sink = {
   {logcie_token_formatter, (void *)"$L/$M/$m"},
-  {logcie_file_writer, NULL},
+  {logcie_file_writer, logcie_file_flush, NULL},
   logcie_filter_and(
     logcie_filter_level_min(LOGCIE_LEVEL_INFO),
     logcie_filter_module_eq("core")

--- a/tests/cplusplus/cpp_filter_not.cpp
+++ b/tests/cplusplus/cpp_filter_not.cpp
@@ -6,7 +6,7 @@
 
 static Logcie_Sink sink = {
   {logcie_token_formatter, (void *)"$M/$m"},
-  {logcie_file_writer, NULL},
+  {logcie_file_writer, logcie_file_flush, NULL},
   logcie_filter_not(logcie_filter_module_eq("quiet")),
 };
 

--- a/tests/filters/filters.c
+++ b/tests/filters/filters.c
@@ -4,7 +4,7 @@
 
 static Logcie_Sink sink = {
   .formatter = {logcie_token_formatter, (void *)"$L/$M/$m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/format_tokens/tokens.c
+++ b/tests/format_tokens/tokens.c
@@ -5,7 +5,7 @@
 
 static Logcie_Sink sink = {
   .formatter = {logcie_token_formatter, NULL},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/levels/levels.c
+++ b/tests/levels/levels.c
@@ -3,7 +3,7 @@
 
 static Logcie_Sink sink = {
   .formatter = {logcie_token_formatter, (void *)"$L $m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/long_lines/long_lines.c
+++ b/tests/long_lines/long_lines.c
@@ -27,7 +27,7 @@ static size_t counting_writer(void *user_data, const Logcie_Log *log, const char
 
 static Logcie_Sink sink = {
   {logcie_token_formatter, (void *)"$m"},
-  {counting_writer, NULL},
+  {counting_writer, logcie_file_flush, NULL},
   {NULL, NULL},
 };
 

--- a/tests/matrix_clang/matrix.c
+++ b/tests/matrix_clang/matrix.c
@@ -15,7 +15,7 @@
 
 static Logcie_Sink sink = {
   .formatter = {logcie_token_formatter, (void *)"$L $m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/matrix_clang/matrix.cpp
+++ b/tests/matrix_clang/matrix.cpp
@@ -15,7 +15,7 @@
 
 static Logcie_Sink sink = {
   {logcie_token_formatter, (void *)"$L $m"},
-  {logcie_file_writer, NULL},
+  {logcie_file_writer, logcie_file_flush, NULL},
   {NULL, NULL},
 };
 

--- a/tests/matrix_clang/test.tspec
+++ b/tests/matrix_clang/test.tspec
@@ -141,3 +141,66 @@ clang++
 -std=c++11 -pedantic -Wall -Wextra -Werror -DLOGCIE_PEDANTIC -I../.. matrix.cpp -o .side_effects/cpp11
 :int return 0
 
+:test clang_c11_ndebug
+:command compile
+:blob executable 5
+clang
+:blob args 84
+-std=c11 -Wall -Wextra -Werror -DNDEBUG -I../.. matrix.c -o .side_effects/c11_ndebug
+:int return 0
+:command run
+:blob executable 24
+.side_effects/c11_ndebug
+:int return 0
+:blob stdout 18
+INFO n=1
+WARN s=x
+
+
+:test clang_c11_autoflush_disable
+:command compile
+:blob executable 5
+clang
+:blob args 113
+-std=c11 -Wall -Wextra -Werror -DLOGCIE_AUTOFLUSH_DISABLE -I../.. matrix.c -o .side_effects/c11_autoflush_disable
+:int return 0
+:command run
+:blob executable 35
+.side_effects/c11_autoflush_disable
+:int return 0
+:blob stdout 18
+INFO n=1
+WARN s=x
+
+
+:test clang_c99_autoflush_level_thread_safe
+:command compile
+:blob executable 5
+clang
+:blob args 159
+-std=c99 -Wall -Wextra -Werror -DLOGCIE_AUTOFLUSH_LEVEL=LOGCIE_LEVEL_TRACE -DLOGCIE_THREAD_SAFE -I../.. matrix.c -o .side_effects/c99_autoflush_trace -lpthread
+:int return 0
+:command run
+:blob executable 33
+.side_effects/c99_autoflush_trace
+:int return 0
+:blob stdout 18
+INFO n=1
+WARN s=x
+
+
+:test clang_cpp11_autoflush_disable
+:command compile
+:blob executable 7
+clang++
+:blob args 147
+-std=c++11 -pedantic -Wall -Wextra -Werror -DLOGCIE_PEDANTIC -DLOGCIE_AUTOFLUSH_DISABLE -I../.. matrix.cpp -o .side_effects/cpp11_autoflush_disable
+:int return 0
+:command run
+:blob executable 37
+.side_effects/cpp11_autoflush_disable
+:int return 0
+:blob stdout 18
+INFO n=1
+WARN s=x
+

--- a/tests/matrix_gcc/matrix.c
+++ b/tests/matrix_gcc/matrix.c
@@ -15,7 +15,7 @@
 
 static Logcie_Sink sink = {
   .formatter = {logcie_token_formatter, (void *)"$L $m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/matrix_gcc/matrix.cpp
+++ b/tests/matrix_gcc/matrix.cpp
@@ -15,7 +15,7 @@
 
 static Logcie_Sink sink = {
   {logcie_token_formatter, (void *)"$L $m"},
-  {logcie_file_writer, NULL},
+  {logcie_file_writer, logcie_file_flush, NULL},
   {NULL, NULL},
 };
 

--- a/tests/matrix_gcc/test.tspec
+++ b/tests/matrix_gcc/test.tspec
@@ -141,3 +141,66 @@ g++
 -std=c++11 -pedantic -Wall -Wextra -Werror -DLOGCIE_PEDANTIC -I../.. matrix.cpp -o .side_effects/cpp11
 :int return 0
 
+:test gcc_c11_ndebug
+:command compile
+:blob executable 3
+gcc
+:blob args 84
+-std=c11 -Wall -Wextra -Werror -DNDEBUG -I../.. matrix.c -o .side_effects/c11_ndebug
+:int return 0
+:command run
+:blob executable 24
+.side_effects/c11_ndebug
+:int return 0
+:blob stdout 18
+INFO n=1
+WARN s=x
+
+
+:test gcc_c11_autoflush_disable
+:command compile
+:blob executable 3
+gcc
+:blob args 113
+-std=c11 -Wall -Wextra -Werror -DLOGCIE_AUTOFLUSH_DISABLE -I../.. matrix.c -o .side_effects/c11_autoflush_disable
+:int return 0
+:command run
+:blob executable 35
+.side_effects/c11_autoflush_disable
+:int return 0
+:blob stdout 18
+INFO n=1
+WARN s=x
+
+
+:test gcc_c99_autoflush_level_thread_safe
+:command compile
+:blob executable 3
+gcc
+:blob args 159
+-std=c99 -Wall -Wextra -Werror -DLOGCIE_AUTOFLUSH_LEVEL=LOGCIE_LEVEL_TRACE -DLOGCIE_THREAD_SAFE -I../.. matrix.c -o .side_effects/c99_autoflush_trace -lpthread
+:int return 0
+:command run
+:blob executable 33
+.side_effects/c99_autoflush_trace
+:int return 0
+:blob stdout 18
+INFO n=1
+WARN s=x
+
+
+:test gcc_cpp11_autoflush_disable
+:command compile
+:blob executable 3
+g++
+:blob args 147
+-std=c++11 -pedantic -Wall -Wextra -Werror -DLOGCIE_PEDANTIC -DLOGCIE_AUTOFLUSH_DISABLE -I../.. matrix.cpp -o .side_effects/cpp11_autoflush_disable
+:int return 0
+:command run
+:blob executable 37
+.side_effects/cpp11_autoflush_disable
+:int return 0
+:blob stdout 18
+INFO n=1
+WARN s=x
+

--- a/tests/module_routing/routing.c
+++ b/tests/module_routing/routing.c
@@ -8,7 +8,7 @@
 
 static Logcie_Sink sink = {
   .formatter = {logcie_token_formatter, (void *)"$M/$L/$m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/modules/default_module.c
+++ b/tests/modules/default_module.c
@@ -3,7 +3,7 @@
 
 static Logcie_Sink sink = {
   .formatter = {logcie_token_formatter, (void *)"$M:$m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/modules/main.c
+++ b/tests/modules/main.c
@@ -6,7 +6,7 @@ void other(void);
 
 static Logcie_Sink sink = {
   .formatter = {logcie_token_formatter, (void *)"$M:$m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/printf_args/printf_args.c
+++ b/tests/printf_args/printf_args.c
@@ -3,7 +3,7 @@
 
 static Logcie_Sink sink = {
   .formatter = {logcie_token_formatter, (void *)"$m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/recursion/recursion.c
+++ b/tests/recursion/recursion.c
@@ -14,7 +14,7 @@ static size_t reentrant_writer(void *user_data, const Logcie_Log *log, const cha
 
 static Logcie_Sink sink = {
   .formatter = {logcie_token_formatter, (void *)"$m"},
-  .writer    = {reentrant_writer, NULL},
+  .writer    = {reentrant_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/render_message/render.c
+++ b/tests/render_message/render.c
@@ -27,7 +27,7 @@ static size_t probe(Logcie_Writer *writer, void *user_data, Logcie_Log log, va_l
   return 0;
 }
 
-static Logcie_Sink sink = {{probe, NULL}, {logcie_file_writer, NULL}, {NULL, NULL}};
+static Logcie_Sink sink = {{probe, NULL}, {logcie_file_writer, logcie_file_flush, NULL}, {NULL, NULL}};
 
 int main(void) {
   logcie_remove_all_sinks();

--- a/tests/sinks/sinks.c
+++ b/tests/sinks/sinks.c
@@ -3,13 +3,13 @@
 
 static Logcie_Sink a = {
   .formatter = {logcie_token_formatter, (void *)"a:$m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 
 static Logcie_Sink b = {
   .formatter = {logcie_token_formatter, (void *)"b:$m"},
-  .writer    = {logcie_file_writer, NULL},
+  .writer    = {logcie_file_writer, logcie_file_flush, NULL},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/thread_safety/concurrent_flush.c
+++ b/tests/thread_safety/concurrent_flush.c
@@ -1,0 +1,89 @@
+/* NOTE: logcie_flush takes the same mutex logcie_log does, and it reads the
+ * sink array while other threads are logging through it. This fixture exists
+ * to put that under ThreadSanitizer.
+ *
+ * NOTE: the flusher is called both from logcie_flush and, at ERROR and above,
+ * from inside logcie_log. Both paths hold the lock, so the counter it bumps
+ * needs no atomics -- and if that ever stops being true, TSan says so here. */
+#define LOGCIE_THREAD_SAFE
+#define LOGCIE_IMPLEMENTATION
+#include "logcie.h"
+
+#include <pthread.h>
+
+#define THREADS          4
+#define LINES_PER_THREAD 250
+#define TOTAL            (THREADS * LINES_PER_THREAD)
+
+static size_t writer_calls = 0;
+static size_t flush_calls  = 0;
+
+static size_t counting_writer(void *user_data, const Logcie_Log *log, const char *bytes, size_t len) {
+  (void)user_data;
+  (void)log;
+  (void)bytes;
+
+  writer_calls++;
+  return len;
+}
+
+static void counting_flush(void *user_data) {
+  (void)user_data;
+  flush_calls++;
+}
+
+static Logcie_Sink sink = {
+  {logcie_token_formatter, (void *)"$M:$m"},
+  {counting_writer, counting_flush, NULL},
+  {NULL, NULL},
+};
+
+static void *logger(void *arg) {
+  long id = (long)arg;
+
+  for (int i = 0; i < LINES_PER_THREAD; i++) {
+    LOGCIE_LOG_MOD("worker", INFO, "thread=%ld line=%d", id, i);
+  }
+
+  return NULL;
+}
+
+static void *flusher(void *arg) {
+  (void)arg;
+
+  for (int i = 0; i < LINES_PER_THREAD; i++) {
+    logcie_flush();
+  }
+
+  return NULL;
+}
+
+int main(void) {
+  pthread_t loggers[THREADS];
+  pthread_t flushers[THREADS];
+
+  logcie_remove_all_sinks();
+  logcie_add_sink(&sink);
+
+  for (long t = 0; t < THREADS; t++) {
+    if (pthread_create(&loggers[t], NULL, logger, (void *)t) != 0) {
+      return 1;
+    }
+
+    if (pthread_create(&flushers[t], NULL, flusher, NULL) != 0) {
+      return 1;
+    }
+  }
+
+  for (int t = 0; t < THREADS; t++) {
+    pthread_join(loggers[t], NULL);
+    pthread_join(flushers[t], NULL);
+  }
+
+  /* NOTE: flush_calls is not asserted exactly. How many flushes land is a
+   * matter of scheduling; that every line arrived and nothing raced is not. */
+  printf("writer_calls=%zu\n", writer_calls);
+  printf("flushed_at_least_once=%d\n", flush_calls > 0);
+  printf("all_accounted_for=%d\n", writer_calls == TOTAL);
+  return 0;
+}

--- a/tests/thread_safety/flush_from_writer.c
+++ b/tests/thread_safety/flush_from_writer.c
@@ -1,0 +1,70 @@
+/* NOTE: logcie_log holds logcie_mutex across the whole sink loop, writers
+ * included, and the mutex is not recursive. A writer calling logcie_flush is
+ * asking for a lock its own thread already holds. Threads contending for that
+ * lock from outside is a different case, covered by concurrent_flush.c, and it
+ * passes whether or not the re-entrancy guard exists.
+ *
+ * NOTE: a deadlock produces no return code to assert on, so this fixture arms
+ * an alarm and reports the hang itself. Without the guard it prints
+ * "deadlocked" and exits 1. */
+#define _POSIX_C_SOURCE 200809L
+
+#define LOGCIE_THREAD_SAFE
+#define LOGCIE_IMPLEMENTATION
+#include "logcie.h"
+
+#include <signal.h>
+#include <unistd.h>
+
+static int writes  = 0;
+static int flushes = 0;
+
+static void on_alarm(int sig) {
+  (void)sig;
+
+  static const char msg[] = "deadlocked\n";
+  ssize_t           n     = write(STDOUT_FILENO, msg, sizeof(msg) - 1);
+
+  (void)n;
+  _exit(1);
+}
+
+static void counting_flush(void *user_data) {
+  (void)user_data;
+  flushes++;
+}
+
+static size_t flushing_writer(void *user_data, const Logcie_Log *log, const char *bytes, size_t len) {
+  (void)user_data;
+  (void)log;
+  (void)bytes;
+
+  writes++;
+  logcie_flush();
+  return len;
+}
+
+static Logcie_Sink sink = {
+  {logcie_token_formatter, (void *)"$m"},
+  {flushing_writer, counting_flush, NULL},
+  {NULL, NULL},
+};
+
+int main(void) {
+  signal(SIGALRM, on_alarm);
+  alarm(5);
+
+  logcie_remove_all_sinks();
+  logcie_add_sink(&sink);
+
+  LOGCIE_INFO("below the autoflush level");
+  printf("after_info: writes=%d flushes=%d\n", writes, flushes);
+
+  /* At ERROR the autoflush path calls the flusher as well, so the writer's own
+   * logcie_flush re-enters a lock that is about to be used again. */
+  LOGCIE_ERROR("at the autoflush level");
+  printf("after_error: writes=%d flushes=%d\n", writes, flushes);
+
+  alarm(0);
+  return 0;
+}

--- a/tests/thread_safety/test.tspec
+++ b/tests/thread_safety/test.tspec
@@ -20,8 +20,8 @@ all_accounted_for=1
 :command compile
 :blob executable 2
 cc
-:blob args 76
--std=c11 -fsanitize=thread -I../.. threads.c -o .side_effects/tsan -lpthread
+:blob args 98
+-std=c11 -fsanitize=thread -Wall -Wextra -Werror -I../.. threads.c -o .side_effects/tsan -lpthread
 :int return 0
 :command run
 :blob executable 18
@@ -32,5 +32,40 @@ cc
 writer_calls=1000
 lines=1000
 intact=1000
+all_accounted_for=1
+
+:test flushing_while_other_threads_log_is_safe
+:command compile
+:blob executable 2
+cc
+:blob args 101
+-std=c11 -Wall -Wextra -Werror -I../.. concurrent_flush.c -o .side_effects/concurrent_flush -lpthread
+:int return 0
+:command run
+:blob executable 30
+.side_effects/concurrent_flush
+:int timeout_ms 30000
+:int return 0
+:blob stdout 62
+writer_calls=1000
+flushed_at_least_once=1
+all_accounted_for=1
+
+
+:test the_same_holds_under_thread_sanitizer_with_flushing
+:command compile
+:blob executable 2
+cc
+:blob args 124
+-std=c11 -fsanitize=thread -Wall -Wextra -Werror -I../.. concurrent_flush.c -o .side_effects/concurrent_flush_tsan -lpthread
+:int return 0
+:command run
+:blob executable 35
+.side_effects/concurrent_flush_tsan
+:int timeout_ms 60000
+:int return 0
+:blob stdout 62
+writer_calls=1000
+flushed_at_least_once=1
 all_accounted_for=1
 

--- a/tests/thread_safety/test.tspec
+++ b/tests/thread_safety/test.tspec
@@ -69,3 +69,36 @@ writer_calls=1000
 flushed_at_least_once=1
 all_accounted_for=1
 
+:test a_writer_can_call_logcie_flush_without_deadlocking
+:command compile
+:blob executable 2
+cc
+:blob args 103
+-std=c11 -Wall -Wextra -Werror -I../.. flush_from_writer.c -o .side_effects/flush_from_writer -lpthread
+:int return 0
+:command run
+:blob executable 31
+.side_effects/flush_from_writer
+:int timeout_ms 30000
+:int return 0
+:blob stdout 63
+after_info: writes=1 flushes=1
+after_error: writes=2 flushes=3
+
+
+:test the_same_holds_when_recursive_logging_is_allowed
+:command compile
+:blob executable 2
+cc
+:blob args 146
+-std=c11 -Wall -Wextra -Werror -DLOGCIE_ALLOW_RECURSIVE_LOGGING -I../.. flush_from_writer.c -o .side_effects/flush_from_writer_recursive -lpthread
+:int return 0
+:command run
+:blob executable 41
+.side_effects/flush_from_writer_recursive
+:int timeout_ms 30000
+:int return 0
+:blob stdout 63
+after_info: writes=1 flushes=1
+after_error: writes=2 flushes=3
+

--- a/tests/thread_safety/threads.c
+++ b/tests/thread_safety/threads.c
@@ -35,7 +35,7 @@ static size_t collecting_writer(void *user_data, const Logcie_Log *log, const ch
 
 static Logcie_Sink sink = {
   {logcie_token_formatter, (void *)"$M:$m"},
-  {collecting_writer, NULL},
+  {collecting_writer, logcie_file_flush, NULL},
   {NULL, NULL},
 };
 

--- a/tests/timestamps/timestamps.c
+++ b/tests/timestamps/timestamps.c
@@ -25,7 +25,7 @@ static size_t capture_writer(void *user_data, const Logcie_Log *log, const char 
 
 static Logcie_Sink sink = {
   .formatter = {logcie_token_formatter, NULL},
-  .writer    = {capture_writer, captured},
+  .writer    = {capture_writer, logcie_file_flush, captured},
   .filter    = {NULL, NULL},
 };
 

--- a/tests/writer_flush/custom_level.c
+++ b/tests/writer_flush/custom_level.c
@@ -1,0 +1,36 @@
+#define LOGCIE_AUTOFLUSH_LEVEL LOGCIE_LEVEL_WARN
+#define LOGCIE_IMPLEMENTATION
+#include "logcie.h"
+
+static int flushes = 0;
+
+static size_t counting_writer(void *user_data, const Logcie_Log *log, const char *bytes, size_t len) {
+  (void)user_data;
+  (void)log;
+  (void)bytes;
+  return len;
+}
+
+static void counting_flush(void *user_data) {
+  (void)user_data;
+  flushes++;
+}
+
+static Logcie_Sink sink = {
+  {logcie_token_formatter, (void *)"$m"},
+  {counting_writer, counting_flush, NULL},
+  {NULL, NULL},
+};
+
+int main(void) {
+  logcie_remove_all_sinks();
+  logcie_add_sink(&sink);
+
+  LOGCIE_INFO("below");
+  printf("after_info=%d\n", flushes);
+
+  LOGCIE_WARN("at the lowered level");
+  printf("after_warn=%d\n", flushes);
+
+  return 0;
+}

--- a/tests/writer_flush/flush.c
+++ b/tests/writer_flush/flush.c
@@ -1,0 +1,67 @@
+#define LOGCIE_IMPLEMENTATION
+#include <string.h>
+
+#include "logcie.h"
+
+static char    buffer[64]    = {0};
+static uint8_t buffer_filled = 0;
+static uint8_t writes        = 0;
+static uint8_t flushes       = 0;
+
+static size_t buffered_writer_flush(void *user_data) {
+  (void)user_data;
+
+  flushes++;
+  size_t res = 0;
+  buffer[63] = '\0';
+
+  res += snprintf(NULL, 0, "%s", buffer);
+  res += fflush(NULL);
+
+  buffer_filled = 0;
+  return res;
+}
+
+// NOTE: printf is still buffered, but we have another buffer here just to actually see flusher working
+static size_t buffered_writer(void *user_data, const Logcie_Log *log, const char *bytes, size_t len) {
+  (void)log;
+  writes++;
+
+  if (buffer_filled + len > 63) {
+    buffered_writer_flush(user_data);
+  }
+
+  memcpy(buffer + buffer_filled, bytes, len);
+  buffer_filled += len;
+  return len;
+}
+
+static Logcie_Sink sink = {
+  {logcie_token_formatter, (void *)"$m"},
+  {buffered_writer, buffered_writer_flush, NULL},
+  {NULL, NULL},
+};
+
+int main(void) {
+  logcie_remove_all_sinks();
+  logcie_add_sink(&sink);
+
+  LOGCIE_INFO("Writing log that not that long enough");
+  LOGCIE_INFO("A little bit more");
+  LOGCIE_INFO("A little bit more x2");
+
+  printf("before: flushes: %d\n", flushes);
+  printf("before: writes: %d\n", writes);
+
+  LOGCIE_INFO("Writing more but not enought");
+
+  printf("more: flushes: %d\n", flushes);
+  printf("more: writes: %d\n", writes);
+
+  logcie_flush();
+
+  printf("after: flushes: %d\n", flushes);
+  printf("after: writes: %d\n", writes);
+
+  return 0;
+}

--- a/tests/writer_flush/flush.c
+++ b/tests/writer_flush/flush.c
@@ -63,5 +63,10 @@ int main(void) {
   printf("after: flushes: %d\n", flushes);
   printf("after: writes: %d\n", writes);
 
+  LOGCIE_ERROR("Still enough space in buffer but it should autoflush");
+
+  printf("autoflush: flushes: %d\n", flushes);
+  printf("autoflush: writes: %d\n", writes);
+
   return 0;
 }

--- a/tests/writer_flush/flush.c
+++ b/tests/writer_flush/flush.c
@@ -3,32 +3,35 @@
 
 #include "logcie.h"
 
-static char    buffer[64]    = {0};
-static uint8_t buffer_filled = 0;
-static uint8_t writes        = 0;
-static uint8_t flushes       = 0;
+#define BUFFER_CAP 64
 
-static size_t buffered_writer_flush(void *user_data) {
+// NOTE: a buffer of its own rather than stdio's, so a flush is observable
+// without fflush(NULL) reaching into streams this sink does not own.
+static char   buffer[BUFFER_CAP];
+static size_t buffer_filled  = 0;
+static int    writes         = 0;
+static int    flushes        = 0;
+static int    plain_writes   = 0;
+static int    second_writes  = 0;
+static int    second_flushes = 0;
+
+static void buffered_flush(void *user_data) {
   (void)user_data;
 
   flushes++;
-  size_t res = 0;
-  buffer[63] = '\0';
-
-  res += snprintf(NULL, 0, "%s", buffer);
-  res += fflush(NULL);
-
   buffer_filled = 0;
-  return res;
 }
 
-// NOTE: printf is still buffered, but we have another buffer here just to actually see flusher working
 static size_t buffered_writer(void *user_data, const Logcie_Log *log, const char *bytes, size_t len) {
   (void)log;
   writes++;
 
-  if (buffer_filled + len > 63) {
-    buffered_writer_flush(user_data);
+  if (buffer_filled + len > BUFFER_CAP) {
+    buffered_flush(user_data);
+  }
+
+  if (len > BUFFER_CAP) {
+    len = BUFFER_CAP;
   }
 
   memcpy(buffer + buffer_filled, bytes, len);
@@ -36,37 +39,82 @@ static size_t buffered_writer(void *user_data, const Logcie_Log *log, const char
   return len;
 }
 
-static Logcie_Sink sink = {
+// NOTE: this sink has no flusher at all, which is legal. The autoflush path
+// used to call through the NULL.
+static size_t plain_writer(void *user_data, const Logcie_Log *log, const char *bytes, size_t len) {
+  (void)user_data;
+  (void)log;
+  (void)bytes;
+  plain_writes++;
+  return len;
+}
+
+static size_t second_writer(void *user_data, const Logcie_Log *log, const char *bytes, size_t len) {
+  (void)user_data;
+  (void)log;
+  (void)bytes;
+  second_writes++;
+  return len;
+}
+
+static void second_flush(void *user_data) {
+  (void)user_data;
+  second_flushes++;
+}
+
+static Logcie_Sink buffered = {
   {logcie_token_formatter, (void *)"$m"},
-  {buffered_writer, buffered_writer_flush, NULL},
+  {buffered_writer, buffered_flush, NULL},
   {NULL, NULL},
 };
 
+static Logcie_Sink plain = {
+  {logcie_token_formatter, (void *)"$m"},
+  {plain_writer, NULL, NULL},
+  {NULL, NULL},
+};
+
+static Logcie_Sink second = {
+  {logcie_token_formatter, (void *)"$m"},
+  {second_writer, second_flush, NULL},
+  {NULL, NULL},
+};
+
+static void report(const char *stage) {
+  printf("%s: w=%d f=%d plain_w=%d second_w=%d second_f=%d\n", stage, writes, flushes, plain_writes, second_writes, second_flushes);
+}
+
 int main(void) {
   logcie_remove_all_sinks();
-  logcie_add_sink(&sink);
+  logcie_add_sink(&buffered);
+  logcie_add_sink(&plain);
+  logcie_add_sink(&second);
 
-  LOGCIE_INFO("Writing log that not that long enough");
-  LOGCIE_INFO("A little bit more");
-  LOGCIE_INFO("A little bit more x2");
-
-  printf("before: flushes: %d\n", flushes);
-  printf("before: writes: %d\n", writes);
-
-  LOGCIE_INFO("Writing more but not enought");
-
-  printf("more: flushes: %d\n", flushes);
-  printf("more: writes: %d\n", writes);
+  LOGCIE_INFO("short");
+  report("below_level");
 
   logcie_flush();
+  report("explicit");
 
-  printf("after: flushes: %d\n", flushes);
-  printf("after: writes: %d\n", writes);
+  LOGCIE_ERROR("at level");
+  report("autoflush_error");
 
-  LOGCIE_ERROR("Still enough space in buffer but it should autoflush");
+  LOGCIE_FATAL("above level");
+  report("autoflush_fatal");
 
-  printf("autoflush: flushes: %d\n", flushes);
-  printf("autoflush: writes: %d\n", writes);
+  buffered.filter = logcie_filter_module_eq("nothing");
+  LOGCIE_ERROR("rejected");
+  report("filtered");
+
+  buffered.filter.filter = NULL;
+  buffered.filter.data   = NULL;
+
+  LOGCIE_INFO("a line long enough on its own to push that sixty four byte buffer past its limit");
+  report("self_flush");
+
+  logcie_remove_all_sinks();
+  logcie_flush();
+  report("no_sinks");
 
   return 0;
 }

--- a/tests/writer_flush/no_autoflush.c
+++ b/tests/writer_flush/no_autoflush.c
@@ -1,0 +1,37 @@
+#define LOGCIE_AUTOFLUSH_DISABLE
+#define LOGCIE_IMPLEMENTATION
+#include "logcie.h"
+
+static int flushes = 0;
+
+static size_t counting_writer(void *user_data, const Logcie_Log *log, const char *bytes, size_t len) {
+  (void)user_data;
+  (void)log;
+  (void)bytes;
+  return len;
+}
+
+static void counting_flush(void *user_data) {
+  (void)user_data;
+  flushes++;
+}
+
+static Logcie_Sink sink = {
+  {logcie_token_formatter, (void *)"$m"},
+  {counting_writer, counting_flush, NULL},
+  {NULL, NULL},
+};
+
+int main(void) {
+  logcie_remove_all_sinks();
+  logcie_add_sink(&sink);
+
+  LOGCIE_ERROR("would autoflush by default");
+  LOGCIE_FATAL("so would this");
+  printf("after_logging=%d\n", flushes);
+
+  logcie_flush();
+  printf("after_explicit=%d\n", flushes);
+
+  return 0;
+}

--- a/tests/writer_flush/test.tspec
+++ b/tests/writer_flush/test.tspec
@@ -9,11 +9,13 @@ cc
 :blob executable 19
 .side_effects/flush
 :int return 0
-:blob stdout 105
+:blob stdout 148
 before: flushes: 1
 before: writes: 3
 more: flushes: 1
 more: writes: 4
 after: flushes: 2
 after: writes: 4
+autoflush: flushes: 3
+autoflush: writes: 5
 

--- a/tests/writer_flush/test.tspec
+++ b/tests/writer_flush/test.tspec
@@ -1,4 +1,4 @@
-:test writer_flush_actually_flushes
+:test flush_reaches_every_sink_that_has_a_flusher
 :command compile
 :blob executable 2
 cc
@@ -9,13 +9,44 @@ cc
 :blob executable 19
 .side_effects/flush
 :int return 0
-:blob stdout 148
-before: flushes: 1
-before: writes: 3
-more: flushes: 1
-more: writes: 4
-after: flushes: 2
-after: writes: 4
-autoflush: flushes: 3
-autoflush: writes: 5
+:blob stdout 369
+below_level: w=1 f=0 plain_w=1 second_w=1 second_f=0
+explicit: w=1 f=1 plain_w=1 second_w=1 second_f=1
+autoflush_error: w=2 f=2 plain_w=2 second_w=2 second_f=2
+autoflush_fatal: w=3 f=3 plain_w=3 second_w=3 second_f=3
+filtered: w=3 f=3 plain_w=4 second_w=4 second_f=4
+self_flush: w=4 f=4 plain_w=5 second_w=5 second_f=4
+no_sinks: w=4 f=4 plain_w=5 second_w=5 second_f=4
+
+
+:test autoflush_disable_stops_automatic_flushing
+:command compile
+:blob executable 2
+cc
+:blob args 83
+-std=c11 -Wall -Wextra -Werror -I../.. no_autoflush.c -o .side_effects/no_autoflush
+:int return 0
+:command run
+:blob executable 26
+.side_effects/no_autoflush
+:int return 0
+:blob stdout 33
+after_logging=0
+after_explicit=1
+
+
+:test autoflush_level_can_be_lowered
+:command compile
+:blob executable 2
+cc
+:blob args 83
+-std=c11 -Wall -Wextra -Werror -I../.. custom_level.c -o .side_effects/custom_level
+:int return 0
+:command run
+:blob executable 26
+.side_effects/custom_level
+:int return 0
+:blob stdout 26
+after_info=0
+after_warn=1
 

--- a/tests/writer_flush/test.tspec
+++ b/tests/writer_flush/test.tspec
@@ -1,0 +1,19 @@
+:test writer_flush_actually_flushes
+:command compile
+:blob executable 2
+cc
+:blob args 69
+-std=c11 -Wall -Wextra -Werror -I../.. flush.c -o .side_effects/flush
+:int return 0
+:command run
+:blob executable 19
+.side_effects/flush
+:int return 0
+:blob stdout 105
+before: flushes: 1
+before: writes: 3
+more: flushes: 1
+more: writes: 4
+after: flushes: 2
+after: writes: 4
+

--- a/tests/writer_metadata/metadata.c
+++ b/tests/writer_metadata/metadata.c
@@ -31,7 +31,7 @@ static size_t routing_writer(void *user_data, const Logcie_Log *log, const char 
 
 static Logcie_Sink sink = {
   {logcie_token_formatter, (void *)"$m"},
-  {routing_writer, NULL},
+  {routing_writer, logcie_file_flush, NULL},
   {NULL, NULL},
 };
 


### PR DESCRIPTION
### Added
- `Logcie_Writer` gained a `flush` field, for destinations that buffer. It is
  called with the same `data` as `write`, and `NULL` means there is nothing to
  flush. `logcie_file_flush` is the built-in one to pair with
  `logcie_file_writer`.
- `logcie_flush()` flushes every registered sink. Call it before exiting, and
  before removing a sink -- logcie does not flush on removal, because closing
  the destination is yours to do. It is safe to call from inside a formatter or
  a writer, unlike logging, which is refused there unless
  `LOGCIE_ALLOW_RECURSIVE_LOGGING` is defined.
- Logs at `LOGCIE_AUTOFLUSH_LEVEL` or above now flush the sink they were
  written to, so a crash does not take the lines explaining it. Defaults to
  `LOGCIE_LEVEL_ERROR`; define `LOGCIE_AUTOFLUSH_DISABLE` to switch it off.

### Fixed
- `logcie.h` builds with `NDEBUG` again. A probe in `logcie_set_colors` was
  used only inside an assertion, so once assertions compiled away
  `-Wall -Wextra -Werror` rejected it.


### Changed
- **You are affected if you initialize `Logcie_Writer` positionally.** The
  struct is now `{write, flush, data}`, so `{my_writer, target}` puts your
  target in the flush slot. Add the flush argument, or `NULL`:
  `{my_writer, NULL, target}`. Designated initializers (`.write`, `.data`) do
  not need changing.
